### PR TITLE
package/man: fix repeated calls

### DIFF
--- a/package/man
+++ b/package/man
@@ -73,7 +73,7 @@ do
   [ -d $mandir/$dir ] || safe mkdir $mandir/$dir
   if [ $usemandoc -eq 0 ]
   then
-    safe gzip $manfile && \
+    safe gzip -kf $manfile && \
          install -m 644 "$manfile.gz" $mandir/$dir/"${manfile#*/}.gz"
   else
     safe install -m 644 $manfile $mandir/$dir/${manfile#*./}


### PR DESCRIPTION
Man source files will now be kept by gzip. And existing gzipped files (from earlier invocation) will silently be overridden.

This should allow package/man to be called multiple times.