### PR TITLE
conf-man: remove trailing space from alternative path

### DIFF
--- a/conf-man
+++ b/conf-man
@@ -2,6 +2,6 @@
 
 Top level directory for man pages instead of manpath
 
-/usr/local/man 
+/usr/local/man
 
 could be an alternative


### PR DESCRIPTION
If a user copied that line to the top, package/man would ignore the directory, because it doesn't exist.